### PR TITLE
gitignore editor recovery files, and `Manifest.toml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 ./logging
 depth.png
 wire.png
+
+PointlightModel/Manifest.toml
+
+# Emacs recovery files
+*~
+
+# Vim recovery files
+*.swp
+*.swo


### PR DESCRIPTION
As mentioned earlier today, we might as well ignore the `foo~` files Emacs creates.  I use vim so my equivalent is `.foo.{swp,swo}` which I've also added.

Also as mentioned, we're trying the Julia recommended practice of not checking in `Manifest.toml`, so let's gitignore that as well.